### PR TITLE
Use more faker providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/*
 /bindata
 .DS_Store
 /dist
+.idea/

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ Download [the latest release from GitHub](https://github.com/mpchadwick/dbanon/r
 mysqldump mydb | dbanon -config=myconfig.yml | gzip > mydb.sql.gz
 ```
 
-The `-config` flag can use bundled configurations or point to the path of a custom configuration file. 
+The `-config` flag should point to the path of a custom configuration file. 
 
 ### Configuration
 
 #### Magento 2
 
-`dbanon` bundles a [default Magento 2 configuration file](etc/magento2.yml). However you almost certainly won't use it directly.
+`dbanon` repository has an example [Magento 2 configuration file](etc/magento2.yml). However you almost certainly won't use it directly.
 
 At minimum, you'll first need to run the `map-eav` subcommand. This translates EAV attribute codes to their respective attribute ids.
 
 You must feed it a `mysqldump` of `eav_entity_type` and `eav_attribute` (in that order).
 
 ```
-mysqldump mydb eav_entity_type eav_attribute | dbanon -config=magento2 map-eav > ~/magento2-mapped.yml
+mysqldump mydb eav_entity_type eav_attribute | dbanon -config=etc/magento2.yml map-eav > ~/magento2-mapped.yml
 ```
 
 `map-eav` will replace the attribute codes in the config file with attribute ids and print an updated config to `stdout`.

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func selfUpdate() error {
 }
 
 func main() {
-	requested := flag.String("config", "", "Configuration to use. magento2 is included out-of-box. Alternately, supply path to file")
+	requested := flag.String("config", "", "Configuration to use, supply path to file")
 	update := flag.Bool("update", false, "Auto update dbanon to the newest version")
 	ver := flag.Bool("version", false, "Get current version")
 	silent := flag.Bool("silent", false, "Disable all logging")

--- a/src/config.go
+++ b/src/config.go
@@ -2,7 +2,6 @@ package dbanon
 
 import (
 	"errors"
-	"github.com/mpchadwick/dbanon/bindata"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"strings"
@@ -29,15 +28,10 @@ func NewConfig(requested string) (*Config, error) {
 	var source []byte
 	var err error
 
-	switch requested {
-	case "magento2":
-		source, _ = bindata.Asset("etc/magento2.yml")
-	default:
-		source, err = ioutil.ReadFile(requested)
-		if err != nil {
-			return c, err
-		}
-	}
+    source, err = ioutil.ReadFile(requested)
+    if err != nil {
+        return c, err
+    }
 
 	yaml.Unmarshal(source, &c)
 

--- a/src/provider.go
+++ b/src/provider.go
@@ -10,11 +10,24 @@ import (
 var fakeEmail = faker.Internet().Email
 
 var rawProviders = map[string]interface{}{
-	"Lorem()":    faker.Lorem(),
-	"Internet()": faker.Internet(),
-	"Commerce()": faker.Commerce(),
-	"Code()":     faker.Code(),
-	"Number()":   faker.Number(),
+    "Address()": faker.Address(),
+    "App()": faker.App(),
+    "Avatar()": faker.Avatar(),
+    "Bitcoin()": faker.Bitcoin(),
+    "Business()": faker.Business(),
+    "Code()": faker.Code(),
+    "Commerce()": faker.Commerce(),
+    "Company()": faker.Company(),
+    "Date()": faker.Date(),
+    "Finance()": faker.Finance(),
+    "Hacker()": faker.Hacker(),
+    "Internet()": faker.Internet(),
+    "Lorem()": faker.Lorem(),
+    "Name()": faker.Name(),
+    "Number()": faker.Number(),
+    "PhoneNumber()": faker.PhoneNumber(),
+    "Team()": faker.Team(),
+    "Time()": faker.Time(),
 }
 
 type Provider struct {


### PR DESCRIPTION
- Use more faker providers
- Stop using builtin magento2 config. Leave it only as an example. One of the reasons is that github.com/mpchadwick/dbanon/bindata no longer exists.